### PR TITLE
Fix #22: Menu bar restore window shown incorrectly on first launch

### DIFF
--- a/mac_app/Sources/TextEchoApp/TextEchoApp.swift
+++ b/mac_app/Sources/TextEchoApp/TextEchoApp.swift
@@ -105,7 +105,7 @@ final class AppModel: ObservableObject {
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) { [weak self] in
             guard let self else { return }
             self.showSetupWizardIfNeeded()
-            let shouldShowRestore = AppConfig.shared.model.firstLaunch || !self.menuBarVisible
+            let shouldShowRestore = !self.menuBarVisible
             if shouldShowRestore {
                 self.showRestoreWindow()
             }


### PR DESCRIPTION
## Summary
- Removes `firstLaunch` from the restore window condition in `AppModel.init`
- The window should only appear when the menu bar icon is actually hidden (`!menuBarVisible`), not unconditionally on first launch

## Root cause
`AppConfig.shared.model.firstLaunch || !self.menuBarVisible` caused the restore window to fire on every first launch even though `menuBarVisible` was `true` (icon was visible).

Refs #22