### PR TITLE
Fix #21: Log text cannot be selected or copied

### DIFF
--- a/mac_app/Sources/TextEchoApp/LogsWindow.swift
+++ b/mac_app/Sources/TextEchoApp/LogsWindow.swift
@@ -50,6 +50,7 @@ struct LogsView: View {
                 Text(logText)
                     .font(.system(size: 11, design: .monospaced))
                     .frame(maxWidth: .infinity, alignment: .leading)
+                    .textSelection(.enabled)
             }
         }
         .padding(16)


### PR DESCRIPTION
## Summary
- Adds `.textSelection(.enabled)` to the `Text(logText)` view in `LogsView`
- One-line fix — SwiftUI `Text` is read-only by default; this modifier enables user selection and copy on macOS 12+

Refs #21