### PR TITLE
Fix #18: Engine hot-swap, correct menu bar model name, skip transcriber on first launch

### DIFF
--- a/mac_app/Sources/TextEchoApp/AppState.swift
+++ b/mac_app/Sources/TextEchoApp/AppState.swift
@@ -14,7 +14,9 @@ final class AppState {
     private let pedalMonitor = StreamDeckPedalMonitor()
     private let trackpadMonitor = TrackpadMonitor()
 
-    private let transcriber: any Transcriber
+    private var transcriber: (any Transcriber)?
+    private var loadedEngine: String = ""
+    private var loadedModel: String = ""
 
     private var settingsWindow: SettingsWindowController?
     private var logsWindow: LogsWindowController?
@@ -29,16 +31,23 @@ final class AppState {
 
     init() {
         let model = AppConfig.shared.model
-        if model.transcriptionEngine == "whisper" {
+        if model.firstLaunch {
+            // Skip transcriber — setup wizard will call finalizeFirstLaunchSetup() on close.
+            transcriber = nil
+        } else if model.transcriptionEngine == "whisper" {
             transcriber = WhisperKitTranscriber(
                 modelName: model.whisperModel,
                 idleTimeout: model.whisperIdleTimeout
             )
+            loadedEngine = "whisper"
+            loadedModel = model.whisperModel
         } else {
             transcriber = ParakeetTranscriber(
                 modelName: model.parakeetModel,
                 idleTimeout: model.whisperIdleTimeout
             )
+            loadedEngine = "parakeet"
+            loadedModel = model.parakeetModel
         }
     }
 
@@ -99,28 +108,70 @@ final class AppState {
         pythonServices.stopAll()
     }
 
-    /// Called by the setup wizard after first-time model selection/loading is done.
-    /// Triggers AppState's own transcriber to preload so it's ready for first recording.
-    func preloadCurrentModel() {
-        guard !hasPreloaded && isCurrentModelCached() else { return }
-        startPreloadTask()
+    /// Called by the setup wizard's onClose callback on first launch.
+    /// Creates the transcriber for the engine/model the user chose, then preloads it.
+    func finalizeFirstLaunchSetup() {
+        guard transcriber == nil else { return }
+        let model = config.model
+        let engine = model.transcriptionEngine
+        if engine == "whisper" {
+            transcriber = WhisperKitTranscriber(modelName: model.whisperModel, idleTimeout: model.whisperIdleTimeout)
+            loadedEngine = "whisper"
+            loadedModel = model.whisperModel
+        } else {
+            transcriber = ParakeetTranscriber(modelName: model.parakeetModel, idleTimeout: model.whisperIdleTimeout)
+            loadedEngine = "parakeet"
+            loadedModel = model.parakeetModel
+        }
+        if isCurrentModelCached() {
+            startPreloadTask()
+        }
+    }
+
+    /// Hot-swaps the transcriber when the engine or model changes in Settings.
+    /// No-op if the engine and model already match the current transcriber.
+    func reloadTranscriber() {
+        let model = config.model
+        let engine = model.transcriptionEngine
+        let modelName = engine == "whisper" ? model.whisperModel : model.parakeetModel
+        guard engine != loadedEngine || modelName != loadedModel else { return }
+
+        let old = transcriber
+        if let old {
+            Task { await old.unload() }
+        }
+
+        transcriber = nil
+        hasPreloaded = false
+        loadedEngine = engine
+        loadedModel = modelName
+
+        if engine == "whisper" {
+            transcriber = WhisperKitTranscriber(modelName: model.whisperModel, idleTimeout: model.whisperIdleTimeout)
+        } else {
+            transcriber = ParakeetTranscriber(modelName: model.parakeetModel, idleTimeout: model.whisperIdleTimeout)
+        }
+
+        if isCurrentModelCached() {
+            startPreloadTask()
+        }
     }
 
     private func startPreloadTask() {
-        guard !hasPreloaded else { return }
+        guard !hasPreloaded, let transcriber else { return }
         hasPreloaded = true
         isModelLoading = true
         NotificationCenter.default.post(name: Self.modelLoadingNotification, object: true)
         overlay.showLoadingModel()
-        Task.detached(priority: .utility) { [weak self] in
+        Task.detached(priority: .utility) { [weak self, transcriber] in
             do {
-                try await self?.transcriber.preload()
+                try await transcriber.preload()
                 await MainActor.run {
-                    self?.logger.info("WhisperKit model preloaded")
+                    self?.logger.info("Model preloaded")
                 }
             } catch {
                 await MainActor.run {
-                    self?.logger.error("WhisperKit preload failed: \(error.localizedDescription)")
+                    self?.logger.error("Model preload failed: \(error.localizedDescription)")
                 }
             }
             await MainActor.run {
@@ -236,6 +287,10 @@ final class AppState {
     }
 
     private func transcribe(audioData: Data, isLLM: Bool) async {
+        guard let transcriber else {
+            await MainActor.run { self.overlay.showError("No transcription model loaded") }
+            return
+        }
         do {
             let text = try await transcriber.transcribe(
                 audioData: audioData,

--- a/mac_app/Sources/TextEchoApp/ParakeetTranscriber.swift
+++ b/mac_app/Sources/TextEchoApp/ParakeetTranscriber.swift
@@ -137,12 +137,12 @@ actor ParakeetTranscriber: Transcriber {
         try await initParakeet()
     }
 
-    private func performUnload() async {
+    func unload() async {
         idleTask?.cancel()
         await asrManager?.cleanup()
         asrManager = nil
         _isModelLoaded = false
-        AppLogger.shared.info("Parakeet model unloaded (idle)")
+        AppLogger.shared.info("Parakeet model unloaded")
     }
 
     /// Checks if Parakeet models are cached locally.
@@ -191,7 +191,7 @@ actor ParakeetTranscriber: Transcriber {
         idleTask = Task { [weak self] in
             do {
                 try await Task.sleep(nanoseconds: UInt64(self?.idleTimeout ?? 3600) * 1_000_000_000)
-                await self?.performUnload()
+                await self?.unload()
             } catch {
                 // Task cancelled — fine
             }

--- a/mac_app/Sources/TextEchoApp/TextEchoApp.swift
+++ b/mac_app/Sources/TextEchoApp/TextEchoApp.swift
@@ -145,6 +145,7 @@ final class AppModel: ObservableObject {
             if self.menuBarVisible != desired {
                 self.applyMenuBarVisibility(desired)
             }
+            self.appState.reloadTranscriber()
             self.refreshHistory()
         })
 
@@ -174,9 +175,16 @@ final class AppModel: ObservableObject {
     }
 
     var currentModelDisplayName: String {
-        let name = AppConfig.shared.model.whisperModel
-        return WhisperKitTranscriber.availableModelList
-            .first(where: { $0.name == name })?.displayName ?? name
+        let config = AppConfig.shared.model
+        if config.transcriptionEngine == "whisper" {
+            let name = config.whisperModel
+            return WhisperKitTranscriber.availableModelList
+                .first(where: { $0.name == name })?.displayName ?? name
+        } else {
+            let name = config.parakeetModel
+            return ParakeetTranscriber.availableModelList
+                .first(where: { $0.name == name })?.displayName ?? name
+        }
     }
 
     private func refreshHistory() {
@@ -244,9 +252,7 @@ final class AppModel: ObservableObject {
             setupWizard = SetupWizardController(onClose: { [weak self] in
                 self?.setupWizard?.close()
                 self?.setupWizard = nil
-                // Wizard already loaded the model into memory inline.
-                // Do NOT call preloadCurrentModel() here — it would trigger a redundant
-                // second load (showing a confusing "loading model" overlay after wizard).
+                self?.appState.finalizeFirstLaunchSetup()
                 self?.appState.restartInputMonitor()
             })
         }

--- a/mac_app/Sources/TextEchoApp/Transcriber.swift
+++ b/mac_app/Sources/TextEchoApp/Transcriber.swift
@@ -4,8 +4,9 @@ import Foundation
 /// WhisperKitTranscriber is the primary implementation; the protocol allows
 /// future backends (e.g. server-side, or fallback to Python daemon) without
 /// changing the call sites in AppState.
-protocol Transcriber {
+protocol Transcriber: Sendable {
     func transcribe(audioData: Data, sampleRate: Double) async throws -> String
     func preload() async throws
+    func unload() async
     var isModelLoaded: Bool { get async }
 }

--- a/mac_app/Sources/TextEchoApp/WhisperKitTranscriber.swift
+++ b/mac_app/Sources/TextEchoApp/WhisperKitTranscriber.swift
@@ -157,11 +157,11 @@ actor WhisperKitTranscriber: Transcriber {
         try await initWhisperKit()
     }
 
-    func unloadModel() {
+    func unload() {
         idleTask?.cancel()
         whisperKit = nil
         _isModelLoaded = false
-        AppLogger.shared.info("WhisperKit model unloaded (idle)")
+        AppLogger.shared.info("WhisperKit model unloaded")
     }
 
     /// WhisperKit downloads models via HuggingFace Hub to ~/Documents/huggingface/models/...
@@ -374,7 +374,7 @@ actor WhisperKitTranscriber: Transcriber {
         idleTask = Task { [weak self] in
             do {
                 try await Task.sleep(nanoseconds: UInt64(self?.idleTimeout ?? 3600) * 1_000_000_000)
-                await self?.unloadModel()
+                await self?.unload()
             } catch {
                 // Task cancelled — that's fine
             }


### PR DESCRIPTION
## Summary

Three related issues in the transcription engine lifecycle, all fixed together:

**1. Engine fixed at launch — no hot-swap**
- `Transcriber` protocol gains `unload() async` and `Sendable` conformance
- `WhisperKitTranscriber.unloadModel()` renamed to `unload()`; `ParakeetTranscriber.performUnload()` exposed as `unload()`
- `AppState.transcriber` changed from `let` to `var` (optional)
- `AppState.reloadTranscriber()` hot-swaps engine/model when they differ from what's loaded; called by `AppModel` on every `textechoConfigChanged` notification

**2. Menu bar always shows Whisper model name**
- `currentModelDisplayName` now branches on `transcriptionEngine` — returns the active engine's display name instead of unconditionally reading `whisperModel`

**3. Transcriber created for wrong engine during first-launch wizard**
- `AppState.init()` skips transcriber creation when `firstLaunch == true`
- New `AppState.finalizeFirstLaunchSetup()` creates the correct transcriber after the wizard's `onClose` fires (config already written by wizard at that point)

Refs #18