### PR TITLE
Fix #20: Multiple wizard issues — model picker, engine tab state, InputMonitor timing

### DIFF
--- a/mac_app/Sources/TextEchoApp/AppState.swift
+++ b/mac_app/Sources/TextEchoApp/AppState.swift
@@ -54,7 +54,11 @@ final class AppState {
         inputMonitor.onEvent = { [weak self] event in
             self?.handleInputEvent(event)
         }
-        inputMonitor.start()
+        // Don't start the event tap during the first-launch wizard — hotkeys would fire
+        // mid-setup. restartInputMonitor() is called from the wizard's onClose callback.
+        if !config.model.firstLaunch {
+            inputMonitor.start()
+        }
 
         recorder.onWaveform = { [weak self] levels in
             self?.overlay.updateWaveform(levels)

--- a/mac_app/Sources/TextEchoApp/SetupWizard.swift
+++ b/mac_app/Sources/TextEchoApp/SetupWizard.swift
@@ -66,8 +66,9 @@ struct SetupWizardView: View {
     @State private var downloadedModels: Set<String> = []
     @State private var downloadError: String? = nil
     @State private var showModelPicker: Bool = false
+    @State private var pendingModelSelection: String = ""  // intermediate binding for model picker sheet
     @State private var loadingModelName: String? = nil   // being loaded into memory
-    @State private var modelReady: Bool = false           // selected model is loaded & ready
+    @State private var modelReadyByModel: [String: Bool] = [:]  // per-model load state
     @State private var capsLockEnabled: Bool = AppConfig.shared.model.capsLockEnabled
     @State private var mouseEnabled: Bool = AppConfig.shared.model.mouseEnabled
     @State private var mouseMode: Int = AppConfig.shared.model.mouseMode
@@ -133,13 +134,18 @@ struct SetupWizardView: View {
         }
         .frame(minWidth: 500, minHeight: 540)
         .sheet(isPresented: $showModelPicker, onDismiss: {
-            // Re-check cache status for all curated models plus any non-curated
-            // model that may have been downloaded inside ModelPickerView.
+            // Only commit the selection if the user explicitly tapped Select/Download inside the sheet.
+            // Tapping Done without any action leaves selectedModel unchanged.
+            if !pendingModelSelection.isEmpty && pendingModelSelection != selectedModel {
+                selectedModel = pendingModelSelection
+                startModelPreload(modelName: pendingModelSelection)
+            }
+            pendingModelSelection = ""
             var names = curatedModels.map(\.name)
             if !names.contains(selectedModel) { names.append(selectedModel) }
             checkCacheStatus(for: names)
         }) {
-            ModelPickerView(selectedModel: $selectedModel)
+            ModelPickerView(selectedModel: $pendingModelSelection)
         }
         .onAppear {
             determineInitialStep()
@@ -157,11 +163,6 @@ struct SetupWizardView: View {
                 checkCacheStatus(for: names)
                 maybeStartPreload(for: selectedModel)
             }
-        }
-        .onChange(of: selectedModel) { _ in
-            // Reset ready state when selection changes.
-            // Preload is triggered explicitly by the "Select" button.
-            modelReady = false
         }
         .onDisappear {
             timer?.invalidate()
@@ -319,7 +320,6 @@ struct SetupWizardView: View {
                 } else {
                     selectedModel = AppConfig.shared.model.whisperModel
                 }
-                modelReady = false
                 downloadError = nil
             }
 
@@ -386,7 +386,7 @@ struct SetupWizardView: View {
                 .buttonStyle(.plain)
             }
 
-            if !modelReady {
+            if !(modelReadyByModel[selectedModel] ?? false) {
                 Text(downloadingModel != nil
                      ? "Downloading model…"
                      : !validatingModels.isEmpty
@@ -408,7 +408,7 @@ struct SetupWizardView: View {
         let isValidating = validatingModels.contains(name)
         let isDownloaded = downloadedModels.contains(name)
         let isLoadingThis = loadingModelName == name
-        let isReadyThis = modelReady && selectedModel == name
+        let isReadyThis = modelReadyByModel[name] ?? false
 
         return HStack(alignment: .top, spacing: 10) {
             VStack(alignment: .leading, spacing: 3) {
@@ -853,7 +853,7 @@ struct SetupWizardView: View {
                     currentStep = .activation
                 }
                 .buttonStyle(.borderedProminent)
-                .disabled(!modelReady)
+                .disabled(!(modelReadyByModel[selectedModel] ?? false))
 
             case .activation:
                 Button("Next") {
@@ -1028,7 +1028,7 @@ struct SetupWizardView: View {
                 }
                 await MainActor.run {
                     loadingModelName = nil
-                    if selectedModel == modelName { modelReady = true }
+                    modelReadyByModel[modelName] = true
                 }
             } catch {
                 await MainActor.run {
@@ -1074,9 +1074,7 @@ struct SetupWizardView: View {
                     await MainActor.run {
                         self.downloadingModel = nil
                         self.downloadedModels.insert(modelName)
-                        if modelName == self.selectedModel {
-                            self.modelReady = true
-                        }
+                        self.modelReadyByModel[modelName] = true
                     }
                 } else {
                     var transcriber: WhisperKitTranscriber? = WhisperKitTranscriber(
@@ -1094,9 +1092,7 @@ struct SetupWizardView: View {
                         self.validatingModels.remove(modelName)
                         if isValid {
                             self.downloadedModels.insert(modelName)
-                            if modelName == self.selectedModel {
-                                self.modelReady = true
-                            }
+                            self.modelReadyByModel[modelName] = true
                         } else {
                             self.downloadError = "Download completed but validation failed. Try again."
                         }


### PR DESCRIPTION
## Summary

Three wizard bugs fixed in `SetupWizard.swift` and `AppState.swift`:

**Bug 1 — All models sheet auto-selects and triggers load on Done**
- Added `pendingModelSelection: String` state (starts as `""`)
- `ModelPickerView` is now opened with `$pendingModelSelection` instead of `$selectedModel`
- `onDismiss` only commits the selection and starts preload when `pendingModelSelection` is non-empty (i.e. the user explicitly tapped Select/Download)
- Tapping Done with no action returns to the wizard unchanged

**Bug 2 — Switching engine tabs loses loaded-model state**
- Replaced `modelReady: Bool` with `modelReadyByModel: [String: Bool]` keyed by model name
- Ready state is now independent per model — switching Parakeet ↔ Whisper tabs and back reflects the actual loaded state for each engine's model
- Removed the `onChange(of: selectedModel)` block that was unconditionally resetting the ready state on every selection change
- Removed the `modelReady = false` reset in `onChange(of: selectedEngine)` for the same reason

**Bug 3 — InputMonitor starts before wizard on first launch**
- `AppState.start()` now guards `inputMonitor.start()` with `!config.model.firstLaunch`
- The wizard's `onClose` callback calls `restartInputMonitor()`, which starts the event tap only after setup completes

Refs #20