### PR TITLE
Fix #17: Move input monitors off the main run loop

### DIFF
--- a/mac_app/Sources/TextEchoApp/InputMonitor.swift
+++ b/mac_app/Sources/TextEchoApp/InputMonitor.swift
@@ -16,12 +16,25 @@ enum InputEvent {
 }
 
 final class InputMonitor {
-    var onEvent: ((InputEvent) -> Void)?
+    /// Setting this property wraps the closure so every call dispatches to the main thread.
+    /// CGEventTap callbacks fire on the dedicated background thread — this keeps
+    /// @MainActor callers (AppState.handleInputEvent) safe without any call-site changes.
+    private var _onEvent: ((InputEvent) -> Void)?
+    var onEvent: ((InputEvent) -> Void)? {
+        get { _onEvent }
+        set {
+            guard let newValue else { _onEvent = nil; return }
+            _onEvent = { event in
+                DispatchQueue.main.async { newValue(event) }
+            }
+        }
+    }
 
     private var eventTap: CFMachPort?
     private var runLoopSource: CFRunLoopSource?
+    private var tapThread: Thread?
+    private var tapRunLoop: CFRunLoop?
     private var configObserver: NSObjectProtocol?
-    private var healthCheckTimer: Timer?
 
     private var triggerButton: Int { AppConfig.shared.triggerButton }
     private var dictationKeyCode: Int { AppConfig.shared.dictationKeyCode }
@@ -65,28 +78,46 @@ final class InputMonitor {
             return
         }
 
-        AppLogger.shared.info("Input monitor started (event tap active)")
-
         runLoopSource = CFMachPortCreateRunLoopSource(kCFAllocatorDefault, eventTap, 0)
-        if let source = runLoopSource {
-            CFRunLoopAddSource(CFRunLoopGetCurrent(), source, .commonModes)
-        }
+        guard let source = runLoopSource else { return }
+
         CGEvent.tapEnable(tap: eventTap, enable: true)
 
-        startHealthCheckTimer()
+        // Run the tap on a dedicated background thread with its own run loop.
+        // A CGEventTap is a synchronous kernel-level filter: the kernel holds every
+        // keyboard/mouse event until our callback returns. On the main run loop, any
+        // main-thread work (timers, UI, etc.) delays the callback and causes macOS to
+        // disable the tap (kCGEventTapDisableByTimeout), dropping input system-wide.
+        // On a background thread only TextEcho's processing is affected.
+        let sem = DispatchSemaphore(value: 0)
+        tapThread = Thread { [weak self] in
+            guard let self else { sem.signal(); return }
+            let rl = CFRunLoopGetCurrent()
+            CFRunLoopAddSource(rl, source, .commonModes)
+            self.tapRunLoop = rl   // written before sem.signal(); main thread reads after wait()
+            sem.signal()
+            CFRunLoopRun()
+        }
+        tapThread?.name = "com.textecho.eventtap"
+        tapThread?.qualityOfService = .userInteractive
+        tapThread?.start()
+        sem.wait()
+
+        AppLogger.shared.info("Input monitor started (event tap active)")
         setupConfigObserverIfNeeded()
         syncCapsLockStateIfNeeded()
     }
 
     func stop() {
-        healthCheckTimer?.invalidate()
-        healthCheckTimer = nil
         if let tap = eventTap {
             CGEvent.tapEnable(tap: tap, enable: false)
         }
-        if let source = runLoopSource {
-            CFRunLoopRemoveSource(CFRunLoopGetCurrent(), source, .commonModes)
+        if let source = runLoopSource, let rl = tapRunLoop {
+            CFRunLoopRemoveSource(rl, source, .commonModes)
+            CFRunLoopStop(rl)
         }
+        tapRunLoop = nil
+        tapThread = nil
         runLoopSource = nil
         eventTap = nil
         if let observer = configObserver {
@@ -155,9 +186,9 @@ final class InputMonitor {
         if button == triggerButton {
             AppLogger.shared.info("Mouse trigger \(down ? "down" : "up") (button=\(button))")
             if down {
-                onEvent?(.triggerDown)
+                _onEvent?(.triggerDown)
             } else {
-                onEvent?(.triggerUp)
+                _onEvent?(.triggerUp)
             }
         }
     }
@@ -167,7 +198,7 @@ final class InputMonitor {
         let keyCode = event.getIntegerValueField(.keyboardEventKeycode)
 
         if keyCode == 53 { // ESC
-            onEvent?(.escape)
+            _onEvent?(.escape)
             return
         }
 
@@ -176,17 +207,17 @@ final class InputMonitor {
 
         if cmd && opt {
             switch keyCode {
-            case 18: onEvent?(.register(1))
-            case 19: onEvent?(.register(2))
-            case 20: onEvent?(.register(3))
-            case 21: onEvent?(.register(4))
-            case 23: onEvent?(.register(5))
-            case 22: onEvent?(.register(6))
-            case 26: onEvent?(.register(7))
-            case 28: onEvent?(.register(8))
-            case 25: onEvent?(.register(9))
-            case 29: onEvent?(.clearRegisters)
-            case 49: onEvent?(.settingsHotkey) // space
+            case 18: _onEvent?(.register(1))
+            case 19: _onEvent?(.register(2))
+            case 20: _onEvent?(.register(3))
+            case 21: _onEvent?(.register(4))
+            case 23: _onEvent?(.register(5))
+            case 22: _onEvent?(.register(6))
+            case 26: _onEvent?(.register(7))
+            case 28: _onEvent?(.register(8))
+            case 25: _onEvent?(.register(9))
+            case 29: _onEvent?(.clearRegisters)
+            case 49: _onEvent?(.settingsHotkey) // space
             default: break
             }
         }
@@ -202,10 +233,10 @@ final class InputMonitor {
                 dictationActive = true
                 if llmSet {
                     dictationLLM = true
-                    onEvent?(.dictateLLMDown)
+                    _onEvent?(.dictateLLMDown)
                 } else {
                     dictationLLM = false
-                    onEvent?(.dictateDown)
+                    _onEvent?(.dictateDown)
                 }
             }
         }
@@ -217,9 +248,9 @@ final class InputMonitor {
         if dictationActive && keyCode == dictationKeyCode {
             dictationActive = false
             if dictationLLM {
-                onEvent?(.dictateLLMUp)
+                _onEvent?(.dictateLLMUp)
             } else {
-                onEvent?(.dictateUp)
+                _onEvent?(.dictateUp)
             }
         }
     }
@@ -230,7 +261,7 @@ final class InputMonitor {
         guard keyCode == 57 else { return } // Caps Lock
         let isOn = event.flags.contains(.maskAlphaShift)
         AppLogger.shared.info("Caps Lock changed: \(isOn ? "ON" : "OFF")")
-        onEvent?(.capsLockChanged(isOn))
+        _onEvent?(.capsLockChanged(isOn))
     }
 
     private func setupConfigObserverIfNeeded() {
@@ -246,38 +277,7 @@ final class InputMonitor {
 
     private func syncCapsLockStateIfNeeded() {
         guard AppConfig.shared.model.capsLockEnabled else { return }
-        onEvent?(.capsLockChanged(NSEvent.modifierFlags.contains(.capsLock)))
-    }
-
-    // MARK: - Health check
-
-    private func startHealthCheckTimer() {
-        healthCheckTimer?.invalidate()
-        healthCheckTimer = Timer.scheduledTimer(withTimeInterval: 30, repeats: true) { [weak self] _ in
-            self?.checkTapHealth()
-        }
-    }
-
-    private func checkTapHealth() {
-        guard let tap = eventTap else {
-            AppLogger.shared.error("Health check: event tap is nil — recreating")
-            restart()
-            return
-        }
-        if !CFMachPortIsValid(tap) {
-            AppLogger.shared.error("Health check: mach port invalidated by macOS — recreating tap")
-            restart()
-            return
-        }
-        if !CGEvent.tapIsEnabled(tap: tap) {
-            AppLogger.shared.warn("Health check: event tap disabled — recreating tap (re-enable insufficient)")
-            restart()
-        }
-    }
-
-    private func restart() {
-        stop()
-        start()
+        _onEvent?(.capsLockChanged(NSEvent.modifierFlags.contains(.capsLock)))
     }
 
     private func modifierFlags(from stored: UInt) -> CGEventFlags {

--- a/mac_app/Sources/TextEchoApp/TrackpadMonitor.swift
+++ b/mac_app/Sources/TextEchoApp/TrackpadMonitor.swift
@@ -20,15 +20,44 @@ final class TrackpadMonitor {
     static let productID = 0x0265 // Magic Trackpad
 
     var gesture: TrackpadGesture = .forceClick
-    var onTriggerDown: (() -> Void)?
-    var onTriggerUp: (() -> Void)?
-    var onConnectionChanged: ((Bool) -> Void)?
+    private var _onTriggerDown: (() -> Void)?
+    var onTriggerDown: (() -> Void)? {
+        get { _onTriggerDown }
+        set {
+            guard let newValue else { _onTriggerDown = nil; return }
+            _onTriggerDown = {
+                DispatchQueue.main.async { newValue() }
+            }
+        }
+    }
+    private var _onTriggerUp: (() -> Void)?
+    var onTriggerUp: (() -> Void)? {
+        get { _onTriggerUp }
+        set {
+            guard let newValue else { _onTriggerUp = nil; return }
+            _onTriggerUp = {
+                DispatchQueue.main.async { newValue() }
+            }
+        }
+    }
+    private var _onConnectionChanged: ((Bool) -> Void)?
+    var onConnectionChanged: ((Bool) -> Void)? {
+        get { _onConnectionChanged }
+        set {
+            guard let newValue else { _onConnectionChanged = nil; return }
+            _onConnectionChanged = { connected in
+                DispatchQueue.main.async { newValue(connected) }
+            }
+        }
+    }
 
     private var manager: IOHIDManager?
     private var connectedDevices: Set<IOHIDDevice> = []
     private var retryTimer: Timer?
     private var retryInterval: TimeInterval = 3.0
     private var retryCount: Int = 0
+    private var monitorThread: Thread?
+    private var monitorRunLoop: CFRunLoop?
 
     // Force click state tracking
     private var clickStage: Int = 0   // 0=none, 1=normal click, 2=force click
@@ -40,10 +69,51 @@ final class TrackpadMonitor {
     var isConnected: Bool { !connectedDevices.isEmpty }
 
     func start() {
+        guard manager == nil, monitorThread == nil else { return }
+
+        let sem = DispatchSemaphore(value: 0)
+        monitorThread = Thread { [weak self] in
+            guard let self else { sem.signal(); return }
+            let runLoop = CFRunLoopGetCurrent()
+            self.monitorRunLoop = runLoop
+            self.startManager(on: runLoop)
+            sem.signal()
+            CFRunLoopRun()
+        }
+        monitorThread?.name = "com.textecho.trackpad"
+        monitorThread?.qualityOfService = .userInteractive
+        monitorThread?.start()
+        sem.wait()
+    }
+
+    func stop() {
+        stopManager()
+    }
+
+    private func stopFromMonitorThread() {
+        stopRetryTimer()
+
+        if let manager, let runLoop = monitorRunLoop {
+            IOHIDManagerClose(manager, IOOptionBits(kIOHIDOptionsTypeNone))
+            IOHIDManagerUnscheduleFromRunLoop(manager, runLoop, CFRunLoopMode.defaultMode.rawValue)
+        }
+
+        manager = nil
+        connectedDevices.removeAll()
+        clickStage = 0
+        triggerActive = false
+        rightButtonDown = false
+
+        if let runLoop = monitorRunLoop {
+            CFRunLoopStop(runLoop)
+        }
+    }
+
+    private func startManager(on runLoop: CFRunLoop) {
         guard manager == nil else { return }
 
-        manager = IOHIDManagerCreate(kCFAllocatorDefault, IOOptionBits(kIOHIDOptionsTypeNone))
-        guard let manager else { return }
+        let manager = IOHIDManagerCreate(kCFAllocatorDefault, IOOptionBits(kIOHIDOptionsTypeNone))
+        self.manager = manager
 
         // Match Apple Magic Trackpad over Bluetooth only — skip built-in trackpad (SPI)
         let matchDict: [String: Any] = [
@@ -67,7 +137,7 @@ final class TrackpadMonitor {
             monitor.deviceDisconnected(device)
         }, selfPtr)
 
-        IOHIDManagerScheduleWithRunLoop(manager, CFRunLoopGetMain(), CFRunLoopMode.defaultMode.rawValue)
+        IOHIDManagerScheduleWithRunLoop(manager, runLoop, CFRunLoopMode.defaultMode.rawValue)
         let result = IOHIDManagerOpen(manager, IOOptionBits(kIOHIDOptionsTypeNone))
         if result == kIOReturnSuccess {
             AppLogger.shared.info("Magic Trackpad monitor started")
@@ -78,16 +148,18 @@ final class TrackpadMonitor {
         startRetryTimer()
     }
 
-    func stop() {
-        stopRetryTimer()
-        guard let manager else { return }
-        IOHIDManagerClose(manager, IOOptionBits(kIOHIDOptionsTypeNone))
-        IOHIDManagerUnscheduleFromRunLoop(manager, CFRunLoopGetMain(), CFRunLoopMode.defaultMode.rawValue)
-        self.manager = nil
-        connectedDevices.removeAll()
-        clickStage = 0
-        triggerActive = false
-        rightButtonDown = false
+    private func stopManager() {
+        guard monitorThread != nil, let runLoop = monitorRunLoop else { return }
+
+        let sem = DispatchSemaphore(value: 0)
+        CFRunLoopPerformBlock(runLoop, CFRunLoopMode.defaultMode.rawValue) { [self] in
+            stopFromMonitorThread()
+            sem.signal()
+        }
+        CFRunLoopWakeUp(runLoop)
+        sem.wait()
+        self.monitorThread = nil
+        self.monitorRunLoop = nil
     }
 
     deinit {
@@ -117,7 +189,7 @@ final class TrackpadMonitor {
         retryInterval = 3.0
         retryCount = 0
         AppLogger.shared.info("Magic Trackpad connected (devices: \(connectedDevices.count))")
-        onConnectionChanged?(true)
+        _onConnectionChanged?(true)
 
         // Filter to button + digitizer pages (skip generic desktop / touch coordinates)
         // Using multiple match via array of dicts
@@ -143,10 +215,10 @@ final class TrackpadMonitor {
             clickStage = 0
             if triggerActive {
                 triggerActive = false
-                onTriggerUp?()
+                _onTriggerUp?()
             }
             rightButtonDown = false
-            onConnectionChanged?(false)
+            _onConnectionChanged?(false)
             startRetryTimer()
         }
     }
@@ -186,11 +258,11 @@ final class TrackpadMonitor {
         if pressed && !triggerActive {
             triggerActive = true
             AppLogger.shared.info("Trackpad force click DOWN")
-            onTriggerDown?()
+            _onTriggerDown?()
         } else if !pressed && triggerActive {
             triggerActive = false
             AppLogger.shared.info("Trackpad force click UP")
-            onTriggerUp?()
+            _onTriggerUp?()
         }
     }
 
@@ -204,10 +276,10 @@ final class TrackpadMonitor {
             rightButtonDown = pressed
             if pressed {
                 AppLogger.shared.info("Trackpad right-click DOWN")
-                onTriggerDown?()
+                _onTriggerDown?()
             } else {
                 AppLogger.shared.info("Trackpad right-click UP")
-                onTriggerUp?()
+                _onTriggerUp?()
             }
         }
     }


### PR DESCRIPTION
## Summary
- move the global `CGEventTap` off the main run loop onto a dedicated background thread
- remove the input monitor health-check restart loop and keep input events marshalled back to the main thread
- move the Magic Trackpad HID manager and retry timer onto a dedicated background run loop and marshal callbacks back to the main thread

## Why
Issue #17 describes a system-wide input drop caused by running synchronous input monitors on the main run loop. When the main thread is busy, the event tap callback can time out, get disabled by macOS, and drop queued keyboard and mouse input. The trackpad monitor also suffers delayed or missed trigger delivery when scheduled on the main run loop.

## Impact
- keyboard and mouse event tap processing no longer depends on main-thread responsiveness
- trackpad trigger detection no longer stalls behind UI or timer work on the main run loop
- `AppState` keeps receiving monitor callbacks on the main thread, so existing app logic remains main-actor-safe

Refs #17

## Validation
- not run locally at the user's request
