### PR TITLE
Fix #34: Remove pre-transcription RMS silence skip

### DIFF
--- a/mac_app/Sources/TextEchoApp/ParakeetTranscriber.swift
+++ b/mac_app/Sources/TextEchoApp/ParakeetTranscriber.swift
@@ -50,10 +50,6 @@ actor ParakeetTranscriber: Transcriber {
         }
     }
 
-    // MARK: - Hallucination filter (shared with WhisperKit — Parakeet is less prone but still possible)
-
-    private static let silenceRMSThreshold: Float = 0.005
-
     // MARK: - Init
 
     init(modelVersion: AsrModelVersion = .v3, idleTimeout: Int = 0) {
@@ -86,13 +82,6 @@ actor ParakeetTranscriber: Transcriber {
 
         // Convert Int16 PCM → Float array
         let floatSamples = convertPCMToFloat(audioData)
-
-        // RMS silence check
-        let rms = computeRMS(floatSamples)
-        if rms < Self.silenceRMSThreshold {
-            AppLogger.shared.info("Skipping transcription: audio too quiet (RMS=\(String(format: "%.6f", rms)))")
-            return ""
-        }
 
         // Resample to 16kHz if needed (FluidAudio expects 16kHz)
         let samples: [Float]
@@ -209,15 +198,6 @@ actor ParakeetTranscriber: Transcriber {
             }
             return floats
         }
-    }
-
-    private func computeRMS(_ samples: [Float]) -> Float {
-        guard !samples.isEmpty else { return 0.0 }
-        var sumSquares: Float = 0.0
-        for s in samples {
-            sumSquares += s * s
-        }
-        return sqrtf(sumSquares / Float(samples.count))
     }
 
     private func resample(_ samples: [Float], from sourceSR: Double, to targetSR: Double) -> [Float] {

--- a/mac_app/Sources/TextEchoApp/WhisperKitTranscriber.swift
+++ b/mac_app/Sources/TextEchoApp/WhisperKitTranscriber.swift
@@ -68,8 +68,6 @@ actor WhisperKitTranscriber: Transcriber {
         "i'm going to",
     ]
 
-    private static let silenceRMSThreshold: Float = 0.005
-
     // MARK: - Init
 
     init(modelName: String = "openai_whisper-large-v3_turbo", idleTimeout: Int = 0) {
@@ -97,13 +95,6 @@ actor WhisperKitTranscriber: Transcriber {
 
         // Convert Int16 PCM → Float array
         let floatSamples = convertPCMToFloat(audioData)
-
-        // RMS silence check
-        let rms = computeRMS(floatSamples)
-        if rms < Self.silenceRMSThreshold {
-            AppLogger.shared.info("Skipping transcription: audio too quiet (RMS=\(String(format: "%.6f", rms)))")
-            return ""
-        }
 
         // Resample to 16kHz if needed
         let samples: [Float]
@@ -391,15 +382,6 @@ actor WhisperKitTranscriber: Transcriber {
             }
             return floats
         }
-    }
-
-    private func computeRMS(_ samples: [Float]) -> Float {
-        guard !samples.isEmpty else { return 0.0 }
-        var sumSquares: Float = 0.0
-        for s in samples {
-            sumSquares += s * s
-        }
-        return sqrtf(sumSquares / Float(samples.count))
     }
 
     private func resample(_ samples: [Float], from sourceSR: Double, to targetSR: Double) -> [Float] {


### PR DESCRIPTION
## Summary

- Removes the RMS silence gate (threshold 0.005 / ~-46 dBFS) from both `ParakeetTranscriber` and `WhisperKitTranscriber`
- This gate silently discarded quiet audio before inference, causing false negatives on whispered or soft speech
- Redundant because Parakeet returns empty text on silence, and WhisperKit has a post-inference hallucination filter

## Changes

- 38 lines deleted across 2 files, 0 added
- Removed: `silenceRMSThreshold`, RMS check block, `computeRMS()` helper
- Untouched: WhisperKit's `isHallucination()` filter, AudioRecorder's silence-based auto-stop

## Test plan

- [ ] Build succeeds (`swift build -c release`)
- [ ] CI passes (Swift CI + CodeQL)
- [ ] Whispered/quiet speech is transcribed correctly
- [ ] Silence still produces no output (no hallucinations)
- [ ] Auto-stop on silence still works (AudioRecorder, separate system)

Closes #34

🤖 Generated with [Claude Code](https://claude.com/claude-code)